### PR TITLE
Switch to using cmake --build and custom path

### DIFF
--- a/00.rocm-core.sh
+++ b/00.rocm-core.sh
@@ -15,9 +15,17 @@ cmake \
   -DPROJECT_VERSION_PATCH=${ROCM_PATCH_VERSION} \
   -DROCM_PATCH_VERSION=${ROCM_LIBPATCH_VERSION} \
   -DROCM_BUILD_VERSION=${CPACK_DEBIAN_PACKAGE_RELEASE} \
+  -B build \
   $ROCM_BUILD_DIR/../src/rocm-core
-make package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/11.rocm-llvm.sh
+++ b/11.rocm-llvm.sh
@@ -25,10 +25,17 @@ cmake \
     -DPACKAGE_VERSION=14.0.0.22204.${ROCM_LIBPATCH_VERSION}-${CPACK_DEBIAN_PACKAGE_RELEASE} \
     -DCPACK_DEBIAN_FILE_NAME=DEB-DEFAULT \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/llvm-project/llvm
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/12.roct-thunk-interface.sh
+++ b/12.roct-thunk-interface.sh
@@ -14,10 +14,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G "Ninja" \
+    -B build \
     $ROCM_GIT_DIR/ROCT-Thunk-Interface/
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/13.rocm-cmake.sh
+++ b/13.rocm-cmake.sh
@@ -14,10 +14,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/rocm-cmake
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/14.rocm-device-libs.sh
+++ b/14.rocm-device-libs.sh
@@ -14,10 +14,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/ROCm-Device-Libs
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/15.rocr-runtime.sh
+++ b/15.rocr-runtime.sh
@@ -14,10 +14,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/ROCR-Runtime/src
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/16.rocminfo.sh
+++ b/16.rocminfo.sh
@@ -14,10 +14,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/rocminfo
-ninja
-ninja package 
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/17.rocm-compilersupport.sh
+++ b/17.rocm-compilersupport.sh
@@ -19,10 +19,17 @@ cmake \
     -DCPACK_PACKAGING_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DCPACK_GENERATOR=DEB \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/ROCm-CompilerSupport/lib/comgr
-ninja
-ninja package
-sudo dpkg -i *.deb
+
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${ROCM_INSTALL_DIR}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build --target package
+  sudo dpkg -i *.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`

--- a/18.hip.sh
+++ b/18.hip.sh
@@ -12,8 +12,12 @@ HIP_DIR=$ROCM_GIT_DIR/HIP
 
 START_TIME=`date +%s`
 
+# There are some perl scripts that require this envar
+HIP_CLANG_PATH="$ROCM_INSTALL_DIR/llvm/bin" \
 cmake \
     -DOFFLOAD_ARCH_STR="$AMDGPU_TARGETS" \
+    -DHIP_CLANG_PATH="$ROCM_INSTALL_DIR/llvm/bin" \
+    -DCMAKE_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
     -DHIP_COMMON_DIR="$HIP_DIR" \
     -DAMD_OPENCL_PATH="$OPENCL_DIR" \
     -DROCCLR_PATH="$ROCCLR_DIR" \
@@ -21,15 +25,22 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCPACK_GENERATOR=DEB \
     -DROCM_PATCH_VERSION=50100 \
-    -DCMAKE_INSTALL_PREFIX=$ROCM_BUILD_DIR/hip/install \
+    -DROCM_PATH="$ROCM_INSTALL_DIR" \
+    -DCMAKE_INSTALL_PREFIX=$ROCM_INSTALL_DIR \
+    -D__HIP_ENABLE_PCH=OFF \
     -G Ninja \
+    -B build \
     $ROCM_GIT_DIR/hipamd
 
-ninja
-# sudo ninja install
-ninja package
-# sudo dpkg -i *.deb
-sudo dpkg -i hip-dev*.deb hip-doc*.deb hip-runtime-amd*.deb hip-samples*.deb
+if [[ $1 = "--cmake-install" ]]; then
+  echo "Cmake install into ${CMAKE_INSTALL_PREFIX}"
+  cmake --build build --target install
+else
+  echo "deb package install"
+  cmake --build build
+  cmake --build build --target package
+  sudo dpkg -i hip-dev*.deb hip-doc*.deb hip-runtime-amd*.deb hip-samples*.deb
+fi
 
 END_TIME=`date +%s`
 EXECUTING_TIME=`expr $END_TIME - $START_TIME`


### PR DESCRIPTION
Add an option to install into a given install prefix. This allows
you to avoid building / installing debian packages in case you
want to build / install into a path without sudo access.

If these changes look good I can update the remaining libraries
and modules too.

Summary of proposed changes:

- use the recommended `cmake --build build --target package` targets
- Allow for install into `$ROCM_INSTALL_DIR` without sudo access or deb files
- Verified to build build up to 18.hip.sh with and without `--cmake-install` and can add the rest once this change is in.
